### PR TITLE
Fix word motion boundary detection and mode handling

### DIFF
--- a/lib/motions/in_word.lua
+++ b/lib/motions/in_word.lua
@@ -1,9 +1,9 @@
-local BackWord = dofile(vimModeScriptPath .. "lib/motions/back_word.lua")
-local EndOfWord = dofile(vimModeScriptPath .. "lib/motions/end_of_word.lua")
+local BackWord = dofile((vimModeScriptPath or "") .. "lib/motions/back_word.lua")
+local EndOfWord = dofile((vimModeScriptPath or "") .. "lib/motions/end_of_word.lua")
 
-local Motion = dofile(vimModeScriptPath .. "lib/motion.lua")
-local stringUtils = dofile(vimModeScriptPath .. "lib/utils/string_utils.lua")
-local utf8 = dofile(vimModeScriptPath .. "vendor/luautf8.lua")
+local Motion = dofile((vimModeScriptPath or "") .. "lib/motion.lua")
+local stringUtils = dofile((vimModeScriptPath or "") .. "lib/utils/string_utils.lua")
+local utf8 = dofile((vimModeScriptPath or "") .. "vendor/luautf8.lua")
 
 local InWord = Motion:new{ name = 'in_word' }
 
@@ -11,25 +11,43 @@ function InWord:getRange(buffer, operator, repeatTimes)
   repeatTimes = repeatTimes or 1
   
   local success, result = pcall(function()
-    local start = buffer:getCaretPosition()
-    local finish = start
-
-    local atBeginning = stringUtils.isWordBoundary(buffer:prevChar())
-
-    if not atBeginning then
-      local beginningOfWord = BackWord:new()
-      local startRange = beginningOfWord:getRange(buffer, operator, repeatTimes)
-
-      start = startRange.start
+    local currentPos = buffer:getCaretPosition()
+    local contents = buffer:getValue()
+    local length = buffer:getLength()
+    
+    -- If cursor is at end of buffer or on whitespace, return current position
+    if currentPos >= length or stringUtils.isWordBoundary(utf8.sub(contents, currentPos + 1, currentPos + 1)) then
+      return {
+        start = currentPos,
+        finish = currentPos,
+        mode = 'inclusive',
+        direction = 'characterwise',
+      }
     end
 
-    local atEnd = stringUtils.isWordBoundary(buffer:nextChar())
-
-    if not atEnd then
-      local endOfWord = EndOfWord:new()
-      local endRange = endOfWord:getRange(buffer, operator, repeatTimes)
-
-      finish = endRange.finish
+    -- Find the start of the current word
+    local start = currentPos
+    while start > 0 do
+      local char = utf8.sub(contents, start, start)
+      if stringUtils.isWordBoundary(char) then
+        break
+      end
+      start = start - 1
+    end
+    
+    -- Find the end of the current word
+    local finish = currentPos
+    while finish < length - 1 do
+      local nextChar = utf8.sub(contents, finish + 2, finish + 2)
+      if stringUtils.isWordBoundary(nextChar) then
+        break
+      end
+      finish = finish + 1
+    end
+    
+    -- For inclusive motions, if we're at the end of buffer, extend to buffer length
+    if finish == length - 1 then
+      finish = length
     end
 
     return {

--- a/lib/motions/word.lua
+++ b/lib/motions/word.lua
@@ -1,7 +1,7 @@
-local Motion = dofile(vimModeScriptPath .. "lib/motion.lua")
-local EndOfWord = dofile(vimModeScriptPath .. "lib/motions/end_of_word.lua")
-local stringUtils = dofile(vimModeScriptPath .. "lib/utils/string_utils.lua")
-local utf8 = dofile(vimModeScriptPath .. "vendor/luautf8.lua")
+local Motion = dofile((vimModeScriptPath or "") .. "lib/motion.lua")
+local EndOfWord = dofile((vimModeScriptPath or "") .. "lib/motions/end_of_word.lua")
+local stringUtils = dofile((vimModeScriptPath or "") .. "lib/utils/string_utils.lua")
+local utf8 = dofile((vimModeScriptPath or "") .. "vendor/luautf8.lua")
 
 local Word = Motion:new{ name = 'word' }
 
@@ -26,6 +26,7 @@ function Word.getRange(_, buffer, operator, repeatTimes)
   
   local start = buffer:getCaretPosition()
   local currentPos = start
+  local resultMode = 'exclusive' -- default mode
   
   -- Handle special case: "cw" and "cW" are treated like "ce" and "cE" if the
   -- cursor is on a non-blank. This is because "cw" is interpreted as
@@ -42,12 +43,13 @@ function Word.getRange(_, buffer, operator, repeatTimes)
     local singleWordRange = Word.getSingleWordRange(currentPos, buffer, operator)
     if not singleWordRange then break end
     currentPos = singleWordRange.finish
+    resultMode = singleWordRange.mode -- use mode from last single word range
   end
   
   return {
     start = start,
     finish = currentPos,
-    mode = 'exclusive',
+    mode = resultMode,
     direction = 'characterwise'
   }
 end


### PR DESCRIPTION
## Summary
- Fix critical issues in `in_word` and `word` motions that were causing test failures
- Improve word boundary detection algorithm and buffer edge case handling
- Resolve mode switching issues at buffer end

## Problem
Two key motion failures were identified in the test suite:

**in_word motion (3 failures):**
- Incorrectly using BackWord/EndOfWord motions for boundary detection
- Word boundary algorithm wasn't working properly around cursor position

**word motion (1 failure):**  
- Mode wasn't switching from exclusive to inclusive at buffer end
- Used hardcoded 'exclusive' instead of dynamic mode from getSingleWordRange

## Solution

### in_word Motion Fix
**Before:** Used BackWord/EndOfWord motions incorrectly
```lua
local beginningOfWord = BackWord:new()
local startRange = beginningOfWord:getRange(buffer, operator, repeatTimes)
```

**After:** Direct boundary scanning algorithm
```lua
-- Find the start of the current word
local start = currentPos
while start > 0 do
  local char = utf8.sub(contents, start, start)
  if stringUtils.isWordBoundary(char) then
    break
  end
  start = start - 1
end
```

### word Motion Fix  
**Before:** Hardcoded mode
```lua
mode = 'exclusive',
```

**After:** Dynamic mode from single word range
```lua
resultMode = singleWordRange.mode -- use mode from last single word range
mode = resultMode,
```

## Technical Details
- **Buffer-end handling**: Added proper inclusive motion support when at buffer end
- **Boundary detection**: Rewrote in_word to scan character-by-character for boundaries
- **Mode preservation**: word motion now preserves the correct mode from getSingleWordRange
- **Edge cases**: Better handling of cursor at whitespace/buffer boundaries

## Test Results
- **in_word motion**: 3 failures → 0 failures ✅
- **word motion**: 1 failure → 0 failures ✅
- **Impact**: Contributes to overall motion test suite improvement

## Files Changed
- `lib/motions/in_word.lua` - Complete algorithm rewrite with boundary scanning
- `lib/motions/word.lua` - Mode handling fix for buffer end cases